### PR TITLE
fix(AAE-1012): add support for Liquibase init container

### DIFF
--- a/.updatebot.yml
+++ b/.updatebot.yml
@@ -2,6 +2,6 @@ github:
   organisations:
   - name: activiti
     repositories:
-    - name: activiti-cloud-application
+    - name: activiti-cloud-full-chart
       branch: develop
       useSinglePullRequest: true

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -56,6 +56,13 @@ A Helm chart for Activiti Cloud Common Templates
 | javaOpts.other | string | `"-XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"` |  |
 | javaOpts.xms | string | `"256m"` |  |
 | javaOpts.xmx | string | `"1024m"` |  |
+| liquibase.args[0] | string | `"-jar"` |  |
+| liquibase.args[1] | string | `"liquibase.jar"` |  |
+| liquibase.enabled | bool | `false` |  |
+| liquibase.env | object | `{}` |  |
+| liquibase.image | string | `nil` |  |
+| liquibase.imagePullPolicy | string | `"IfNotPresent"` |  |
+| liquibase.tag | string | `nil` |  |
 | livenessProbe.failureThreshold | int | `4` |  |
 | livenessProbe.initialDelaySeconds | int | `60` |  |
 | livenessProbe.path | string | `nil` | set liveness probe path, each service should provide its own value or default @default empty, each service should provide its own value or template or default probePath |

--- a/charts/common/templates/_backend_env.yaml
+++ b/charts/common/templates/_backend_env.yaml
@@ -48,4 +48,8 @@
 - name: SPRING_JPA_HIBERNATE_DDL_AUTO
   value: {{ .Values.db.ddlAuto }}
   {{- end }}
+  {{- if .Values.liquibase.enabled }}
+- name: SPRING_LIQUIBASE_ENABLED
+  value: "false"
+  {{- end }}
 {{- end -}}

--- a/charts/common/templates/_deployment.yaml
+++ b/charts/common/templates/_deployment.yaml
@@ -45,7 +45,7 @@ spec:
             image: {{ .Values.liquibase.image | default .Values.image.repository }}:{{ .Values.liquibase.tag | default .Values.image.tag }}
             imagePullPolicy: {{ .Values.liquibase.imagePullPolicy }}
             args:
-            {{- toYaml .Values.liquibase.args | nindent 12 }}
+            {{- toYaml .Values.liquibase.args | nindent 14 }}
             env:
               - name: SPRING_DATASOURCE_URL
                 value: {{ .Values.db.uri | default (tpl "jdbc:postgresql://{{ include \"common.postgresql.fullname\" . }}:{{ .Values.postgresql.port }}/{{ .Values.db.username }}" .) }}

--- a/charts/common/templates/_deployment.yaml
+++ b/charts/common/templates/_deployment.yaml
@@ -70,7 +70,7 @@ spec:
                 value: {{ .Values.db.generateDdl | quote }}
               - name: SPRING_JPA_HIBERNATE_DDL_AUTO
                 value: {{ .Values.db.ddlAuto }}
-        {{- end }}        
+        {{- end }}
         {{- with .Values.extraInitContainers }}
         {{- tpl . $ | nindent 8 }}
         {{- end -}}

--- a/charts/common/templates/_deployment.yaml
+++ b/charts/common/templates/_deployment.yaml
@@ -73,7 +73,7 @@ spec:
               {{- range $key, $val := .Values.liquibase.env }}
               - name: {{ $key }}
                 value: {{ tpl $val $ | quote }}
-              {{- end }}                
+              {{- end }}
         {{- end }}
         {{- with .Values.extraInitContainers }}
         {{- tpl . $ | nindent 8 }}

--- a/charts/common/templates/_deployment.yaml
+++ b/charts/common/templates/_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       imagePullSecrets:
         {{- . | nindent 8 }}
       {{- end }}
-      {{- if or .Values.postgresql.enabled .Values.extraInitContainers }}
+      {{- if or .Values.postgresql.enabled .Values.liquibase.enabled .Values.extraInitContainers }}
       initContainers:
         {{- if .Values.postgresql.enabled }}
           - name: pgchecker
@@ -40,6 +40,37 @@ spec:
             resources:
               {{- toYaml .Values.pgchecker.resources | nindent 14 }}
         {{- end }}
+        {{- if .Values.liquibase.enabled }}
+          - name: liquibase
+            image: {{ .Values.liquibase.image | default .Values.image.repository }}:{{ .Values.liquibase.tag | default .Values.image.tag }}
+            imagePullPolicy: {{ .Values.liquibase.imagePullPolicy }}
+            args:
+            {{- toYaml .Values.liquibase.args | nindent 12 }}
+            env:
+              - name: SPRING_DATASOURCE_URL
+                value: {{ .Values.db.uri | default (tpl "jdbc:postgresql://{{ include \"common.postgresql.fullname\" . }}:{{ .Values.postgresql.port }}/{{ .Values.db.username }}" .) }}
+              - name: SPRING_DATASOURCE_DRIVER_CLASS_NAME
+                value: {{ .Values.db.driver }}
+              - name: SPRING_DATASOURCE_USERNAME
+                value: {{ .Values.db.username }}
+              - name: SPRING_DATASOURCE_PASSWORD
+                {{- if .Values.db.password }}
+                value: {{ .Values.db.password | quote }}
+                {{- else if .Values.postgresql.enabled }}
+                valueFrom:
+                  secretKeyRef:
+                    name: {{ include "common.postgresql.fullname" . }}
+                    key: postgresql-password
+                {{- else }}
+                value: ""
+                {{- end }}
+              - name: SPRING_JPA_DATABASE_PLATFORM
+                value: {{ .Values.db.platform }}
+              - name: SPRING_JPA_GENERATE_DDL
+                value: {{ .Values.db.generateDdl | quote }}
+              - name: SPRING_JPA_HIBERNATE_DDL_AUTO
+                value: {{ .Values.db.ddlAuto }}
+        {{- end }}        
         {{- with .Values.extraInitContainers }}
         {{- tpl . $ | nindent 8 }}
         {{- end -}}

--- a/charts/common/templates/_deployment.yaml
+++ b/charts/common/templates/_deployment.yaml
@@ -70,6 +70,10 @@ spec:
                 value: {{ .Values.db.generateDdl | quote }}
               - name: SPRING_JPA_HIBERNATE_DDL_AUTO
                 value: {{ .Values.db.ddlAuto }}
+              {{- range $key, $val := .Values.liquibase.env }}
+              - name: {{ $key }}
+                value: {{ tpl $val $ | quote }}
+              {{- end }}                
         {{- end }}
         {{- with .Values.extraInitContainers }}
         {{- tpl . $ | nindent 8 }}

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -52,6 +52,16 @@ replicaCount: 1
 # extraInitContainers -- adds extraInitContainers to deployments
 extraInitContainers: ""
 
+liquibase:
+  enabled: false
+  image: # defaults to image.repository
+  args:
+    - -jar
+    - liquibase.jar
+  tag: # defaults to image.tag
+  imagePullPolicy: IfNotPresent
+  env: {}
+
 pgchecker:
   image:
     # pgchecker.image.repository -- Docker image used to check Postgresql readiness at startup


### PR DESCRIPTION
Provides support to enable Liquibase init container with the following default values:

```yaml
liquibase:
  enabled: false
  image: # defaults to image.repository
  args:
    - -jar
    - liquibase.jar
  tag: # defaults to image.tag
  imagePullPolicy: IfNotPresent
  env: {}
```  