### PR TITLE
fix: add javaOpts.extra configuration values for custom options

### DIFF
--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -73,7 +73,7 @@ A Helm chart for Activiti Cloud Common Templates
 | ingress.tls | string | `nil` | set to true in order to enable TLS on the ingress record |
 | ingress.tlsSecret | string | `nil` | if tls is set to true, you must declare what secret will store the key/certificate for TLS |
 | initContainers | list | `[]` | add additional initContainers as list |
-| javaOpts.extra | string | `""` | provide extra options for Java runtime, i.e. -Djavax.net.ssl.truststore=/mnt/secrets/cacerts   |
+| javaOpts.extra | string | `""` | provide extra options for Java runtime, i.e. -Djavax.net.ssl.truststore=/mnt/secrets/cacerts |
 | javaOpts.other | string | `"-XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"` |  |
 | javaOpts.xms | string | `"256m"` |  |
 | javaOpts.xmx | string | `"1024m"` |  |

--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -73,6 +73,7 @@ A Helm chart for Activiti Cloud Common Templates
 | ingress.tls | string | `nil` | set to true in order to enable TLS on the ingress record |
 | ingress.tlsSecret | string | `nil` | if tls is set to true, you must declare what secret will store the key/certificate for TLS |
 | initContainers | list | `[]` | add additional initContainers as list |
+| javaOpts.extra | string | `""` | provide extra options for Java runtime, i.e. -Djavax.net.ssl.truststore=/mnt/secrets/cacerts   |
 | javaOpts.other | string | `"-XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90"` |  |
 | javaOpts.xms | string | `"256m"` |  |
 | javaOpts.xmx | string | `"1024m"` |  |

--- a/charts/common/templates/_backend_env.yaml
+++ b/charts/common/templates/_backend_env.yaml
@@ -54,7 +54,7 @@ Create backend service.envType env.
 */}}
 {{- define "common.backend-env" -}}
 - name: JAVA_OPTS
-  value: "-Xmx{{ .Values.javaOpts.xmx }} -Xms{{ .Values.javaOpts.xms }} {{ .Values.javaOpts.other}}"
+  value: "-Xmx{{ .Values.javaOpts.xmx }} -Xms{{ .Values.javaOpts.xms }} {{ .Values.javaOpts.other }} {{ .Values.javaOpts.extra }}"
 - name: SPRING_APPLICATION_NAME
   value: {{ .Values.service.name | default (include "common.fullname" .) }}
 {{- if and .Values.rabbitmq.enabled (not .Values.messaging.enabled) }}

--- a/charts/common/tests/javaOpts_test.yaml
+++ b/charts/common/tests/javaOpts_test.yaml
@@ -1,0 +1,30 @@
+suite: test javaOpts
+templates:
+  - deployment.yaml
+tests:
+  - it: should render javaOpts defaults
+    set:
+      enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JAVA_OPTS
+            value: '-Xmx1024m -Xms256m -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+              -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+              -XX:AdaptiveSizePolicyWeight=90 '
+  - it: should render javaOpts extra
+    set:
+      enabled: true
+      javaOpts.extra: >-
+        -Djavax.net.ssl.trustStore=/mnt/secrets/cacerts
+        -Djavax.net.ssl.trustStorePassword=changeit
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: JAVA_OPTS
+            value: '-Xmx1024m -Xms256m -XX:+UnlockExperimentalVMOptions -Dsun.zip.disableMemoryMapping=true
+              -XX:+UseParallelGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10 -XX:GCTimeRatio=4
+              -XX:AdaptiveSizePolicyWeight=90 -Djavax.net.ssl.trustStore=/mnt/secrets/cacerts
+              -Djavax.net.ssl.trustStorePassword=changeit'

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -207,6 +207,8 @@ javaOpts:
     -XX:MaxHeapFreeRatio=10
     -XX:GCTimeRatio=4
     -XX:AdaptiveSizePolicyWeight=90
+  # javaOpts.extra -- provide extra options for Java runtime, i.e. -Djavax.net.ssl.truststore=/mnt/secrets/cacerts  
+  extra: ""
 
 # probePath -- set default probe path for both liveness and readiness
 # @default empty, each service should provide its own value or template, i.e. '{{ tpl .Values.ingress.path . }}/actuator/health'

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -207,7 +207,7 @@ javaOpts:
     -XX:MaxHeapFreeRatio=10
     -XX:GCTimeRatio=4
     -XX:AdaptiveSizePolicyWeight=90
-  # javaOpts.extra -- provide extra options for Java runtime, i.e. -Djavax.net.ssl.truststore=/mnt/secrets/cacerts  
+  # javaOpts.extra -- provide extra options for Java runtime, i.e. -Djavax.net.ssl.truststore=/mnt/secrets/cacerts
   extra: ""
 
 # probePath -- set default probe path for both liveness and readiness


### PR DESCRIPTION
in order to provide custom Java options via values, i.e:

```yaml
javaOpts:
  extra: >-
    -Djavax.net.ssl.trustStore=/mnt/secrets/cacerts
    -Djavax.net.ssl.trustStorePassword=changeit
```