### PR TITLE
fix(GH-3702): add test coverage for global.extraEnv values

### DIFF
--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -161,7 +161,7 @@ tests:
       name: activiti-app
     set:
       enabled: true
-      global.extraEnv: |-
+      global.extraEnv: |
         - name: ACTIVITI_CLOUD_APPLICATION_NAME
           value: "{{ .Release.Name }}"
     asserts:


### PR DESCRIPTION
Part of https://github.com/Activiti/Activiti/issues/3702