### PR TITLE
fix: add test coverage for deployment health probes

### DIFF
--- a/charts/common/tests/deployment_test.yaml
+++ b/charts/common/tests/deployment_test.yaml
@@ -206,11 +206,11 @@ tests:
       enabled: true
       ingress.path: /rb
       probePath: "{{ tpl .Values.ingress.path . }}/actuator/health"
-      readinessProbe.path: "{{ tpl .Values.ingress.path . }}/actuator/health/liveness"
+      readinessProbe.path: "{{ tpl .Values.ingress.path . }}/actuator/health/readiness"
     asserts:
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
-          value: /rb/actuator/health/liveness
+          value: /rb/actuator/health/readiness
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
           value: /rb/actuator/health


### PR DESCRIPTION
This PR adds test coverage for deployment health probes:

- [x] probePath
- [x] livenessProbe.path
- [x] readinessProbe.path

Part of https://github.com/Activiti/Activiti/issues/3747