### PR TITLE
Create a template to support for Horizontal Pod Autoscaling (HPA)

### DIFF
--- a/charts/common/README.md
+++ b/charts/common/README.md
@@ -66,6 +66,7 @@ A Helm chart for Activiti Cloud Common Templates
 | global.rabbitmq.password | string | `"guest"` |  |
 | global.rabbitmq.username | string | `"guest"` |  |
 | global.registryPullSecrets | list | `[]` | configure pull secrets for all deployments |
+| hpa.enabled | bool | `false` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"activiti/replaceme"` |  |
 | image.tag | string | `"latest"` |  |

--- a/charts/common/templates/_hpa.tpl
+++ b/charts/common/templates/_hpa.tpl
@@ -1,0 +1,37 @@
+{{- define "common.hpa.tpl" -}}
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "common.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "common.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  {{- if .Values.hpa.cpu }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.cpu }}
+  {{- end }}
+  {{- if .Values.hpa.memory }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: AverageValue
+          averageValue: {{ .Values.hpa.memory | quote }}
+  {{- end }}
+{{- end -}}
+
+{{- define "common.hpa" -}}
+  {{- if index (first .) "Values" "hpa" "enabled" -}}
+    {{- template "common.util.merge" (append . "common.hpa.tpl") -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/common/templates/_hpa.tpl
+++ b/charts/common/templates/_hpa.tpl
@@ -28,6 +28,7 @@ spec:
           type: AverageValue
           averageValue: {{ .Values.hpa.memory | quote }}
   {{- end }}
+  {{- if or (not (hasKey .Values.hpa "scalingPolicesEnabled")) .Values.hpa.scalingPolicesEnabled }}
   behavior:
     scaleDown:
       policies:
@@ -38,6 +39,7 @@ spec:
         value: 15
         periodSeconds: 60
       selectPolicy: Max
+  {{- end }}
 {{- end -}}
 
 {{- define "common.hpa" -}}

--- a/charts/common/templates/_hpa.tpl
+++ b/charts/common/templates/_hpa.tpl
@@ -28,6 +28,16 @@ spec:
           type: AverageValue
           averageValue: {{ .Values.hpa.memory | quote }}
   {{- end }}
+  behavior:
+    scaleDown:
+      policies:
+      - type: Pods
+        value: 1
+        periodSeconds: 60
+      - type: Percent
+        value: 15
+        periodSeconds: 60
+      selectPolicy: Max
 {{- end -}}
 
 {{- define "common.hpa" -}}

--- a/charts/common/templates/_hpa.tpl
+++ b/charts/common/templates/_hpa.tpl
@@ -7,7 +7,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
-    kind: Deployment
+    kind: {{ if and .Values.messaging.enabled .Values.global.messaging.partitioned (eq .Values.messaging.role "consumer") }}StatefulSet{{ else }}Deployment{{ end }}
     name: {{ template "common.fullname" . }}
   minReplicas: {{ .Values.hpa.minReplicas }}
   maxReplicas: {{ .Values.hpa.maxReplicas }}

--- a/charts/common/templates/hpa.yaml
+++ b/charts/common/templates/hpa.yaml
@@ -1,0 +1,5 @@
+{{- if .Values.enabled -}}
+{{- template "common.hpa" (list . "activiti.cloud.hpa") -}}
+{{- end -}}
+{{- define "activiti.cloud.hpa" -}}
+{{- end -}}

--- a/charts/common/tests/hpa_test.yaml
+++ b/charts/common/tests/hpa_test.yaml
@@ -1,0 +1,97 @@
+suite: test runtime bundle hpa
+templates:
+  - hpa.yaml
+tests:
+  - it: should render nothing if not enabled
+    set:
+      enabled: true
+      hpa:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should render nothing if hpa.enabled=false
+    set:
+      enabled: true
+      hpa:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should render minReplicas
+    set:
+      enabled: true
+      hpa:
+        enabled: true
+        minReplicas: 5
+        maxReplicas: 10
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.minReplicas
+          value: 5
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+  - it: should render the releaseName in the metadata.name
+    release:
+      name: rb
+    set:
+      enabled: true
+      hpa:
+        enabled: true
+    asserts:
+     - equal:
+          path: metadata
+          value:
+            name: rb-common
+            namespace: NAMESPACE
+  - it: should render the releaseName in the metadata.name
+    release:
+      name: rb
+    set:
+      enabled: true
+      hpa:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef
+          value:
+            apiVersion: apps/v1
+            kind: Deployment
+            name: rb-common
+  - it: should render the cpu resource
+    set:
+      enabled: true
+      hpa:
+        enabled: true
+        cpu: 60
+    asserts:
+     - contains:
+        path: spec.metrics
+        content:
+          type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 60
+  - it: should render the memory resource
+    set:
+      enabled: true
+      hpa:
+        enabled: true
+        memory: 1500k
+    asserts:
+     - contains:
+        path: spec.metrics
+        content:
+          type: Resource
+          resource:
+            name: memory
+            target:
+              type: AverageValue
+              averageValue: 1500k

--- a/charts/common/tests/hpa_test.yaml
+++ b/charts/common/tests/hpa_test.yaml
@@ -113,3 +113,12 @@ tests:
               value: 15
               periodSeconds: 60
             selectPolicy: Max
+  - it: should not render the scaling policies when disabled
+    set:
+      enabled: true
+      hpa:
+        enabled: true
+        scalingPolicesEnabled: false
+    asserts:
+     - isNull:
+        path: spec.behavior

--- a/charts/common/tests/hpa_test.yaml
+++ b/charts/common/tests/hpa_test.yaml
@@ -95,3 +95,21 @@ tests:
             target:
               type: AverageValue
               averageValue: 1500k
+  - it: should render the scaling policies
+    set:
+      enabled: true
+      hpa:
+        enabled: true
+    asserts:
+     - equal:
+        path: spec.behavior
+        value:
+          scaleDown:
+            policies:
+            - type: Pods
+              value: 1
+              periodSeconds: 60
+            - type: Percent
+              value: 15
+              periodSeconds: 60
+            selectPolicy: Max

--- a/charts/common/tests/hpa_test.yaml
+++ b/charts/common/tests/hpa_test.yaml
@@ -2,15 +2,13 @@ suite: test runtime bundle hpa
 templates:
   - hpa.yaml
 tests:
-  - it: should render nothing if not enabled
+  - it: should render nothing when not enabled
     set:
-      enabled: true
-      hpa:
-        enabled: false
+      enabled: false
     asserts:
       - hasDocuments:
           count: 0
-  - it: should render nothing if hpa.enabled=false
+  - it: should render nothing when hpa.enabled=false
     set:
       enabled: true
       hpa:

--- a/charts/common/tests/hpa_test.yaml
+++ b/charts/common/tests/hpa_test.yaml
@@ -16,7 +16,7 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-  - it: should render minReplicas
+  - it: should render minReplicas and maxReplicas
     set:
       enabled: true
       hpa:

--- a/charts/common/tests/hpa_test.yaml
+++ b/charts/common/tests/hpa_test.yaml
@@ -49,7 +49,27 @@ tests:
           value:
             name: rb-common
             namespace: NAMESPACE
-  - it: should render the releaseName in the metadata.name
+  - it: should render Kind StatefulSet when role is consumer
+    release:
+      name: rb
+    set:
+      enabled: true
+      global:
+        messaging:
+          partitioned: true
+      messaging:
+        enabled: true
+        role: consumer
+      hpa:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.scaleTargetRef
+          value:
+            apiVersion: apps/v1
+            kind: StatefulSet
+            name: rb-common
+  - it: should render Kind Deployment when role is not consumer
     release:
       name: rb
     set:

--- a/charts/common/values.yaml
+++ b/charts/common/values.yaml
@@ -328,3 +328,6 @@ initContainers: []
 
 # sidecars -- add additional sidecar containers as list
 sidecars: []
+
+hpa:
+  enabled: false


### PR DESCRIPTION
Horizontal Pod Autoscaling support for the microservices `runtime-bundle` and `activiti-cloud-query`.

HPA allows to scale up or down the number of pods when the metrics (CPU and memory) collected on the workload cross a threshold.

A new configuration (similar to the following one) is possible:

```yaml
runtime-bundle:
  hpa:
    enabled: true
    minReplicas: 1
    maxReplicas: 6
    cpu: 90
    memory: "2000Mi"
activiti-cloud-query:
  hpa:
    enabled: true
    minReplicas: 1
    maxReplicas: 4
    cpu: 90
```

These values automatically scale the ReplicaSet when the average CPU consumption rises above 90% or the memory consumption overcomes 2GB.

Two scaleDown policies have been added by default to the HPA configuration to avoid scaling down too quickly.
```yaml
scaleDown:
    policies:
      - type: Pods
        value: 1
        periodSeconds: 60
      - type: Percent
        value: 15
        periodSeconds: 60
      selectPolicy: Max
```

Ref: [Activiti/Activiti#3791](https://github.com/Activiti/Activiti/issues/3791)