### PR TITLE
AAE-16060 Update helm-release-and-publish action to fix build ad rc and workflows concurrency errors 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
 
       - id: helm-release-and-publish
         name: Release and publish helm chart
-        uses: Wandalen/wretry.action@v1.3.0
+        uses: igdianov/wretry.action@master
         env:
           GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,9 +83,9 @@ jobs:
         name: Release and publish helm chart
         uses: Wandalen/wretry.action@v1.3.0
         with:
-          action: Alfresco/alfresco-build-tools/.github/actions/helm-release-and-publish@v1.36.0
           attempt_limit: 3
           attempt_delay: 2000
+          action: Alfresco/alfresco-build-tools/.github/actions/helm-release-and-publish@v1.36.0
           with: |
             version: ${{ steps.calculate-next-internal-version.outputs.next-prerelease }}
             chart-dir: ${{ env.CHART_DIR }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,6 +79,14 @@ jobs:
         with:
           next-version: ${{ steps.helm-parse-next-release.outputs.next-release }}
 
+      - name: Test Retry Action
+        uses: igdianov/wretry.action@master
+        continue-on-error: true
+        with:
+          attempt_limit: 5
+          attempt_delay: 1000
+          command: exit 1
+
       - id: helm-release-and-publish
         name: Release and publish helm chart
         uses: igdianov/wretry.action@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
 
       - id: helm-release-and-publish
         name: Release and publish helm chart
-        uses: Alfresco/alfresco-build-tools/.github/actions/helm-release-and-publish@v1.36.0
+        uses: Alfresco/alfresco-build-tools/.github/actions/helm-release-and-publish@dev-igdianov-AAE-16060
         with:
           version: ${{ steps.calculate-next-internal-version.outputs.next-prerelease }}
           chart-dir: ${{ env.CHART_DIR }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,33 +79,19 @@ jobs:
         with:
           next-version: ${{ steps.helm-parse-next-release.outputs.next-release }}
 
-      - name: Test Retry Action
-        uses: igdianov/wretry.action@master
-        continue-on-error: true
-        with:
-          attempt_limit: 5
-          attempt_delay: 1000
-          command: exit 1
-
       - id: helm-release-and-publish
         name: Release and publish helm chart
-        uses: igdianov/wretry.action@master
-        env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        uses: Alfresco/alfresco-build-tools/.github/actions/helm-release-and-publish@v1.36.0
         with:
-          attempt_limit: 3
-          attempt_delay: 2000
-          action: Alfresco/alfresco-build-tools/.github/actions/helm-release-and-publish@v1.36.0
-          with: |
-            version: ${{ steps.calculate-next-internal-version.outputs.next-prerelease }}
-            chart-dir: ${{ env.CHART_DIR }}
-            helm-repository: ${{ env.HELM_REPO }}
-            helm-repository-branch: ${{ env.HELM_REPO_BRANCH }}
-            helm-repository-subfolder: ${{ env.HELM_REPO_SUBFOLDER }}
-            helm-repository-base-url: ${{ env.HELM_REPO_BASE_URL }}
-            helm-repository-token: ${{ secrets.BOT_GITHUB_TOKEN }}
-            git-username: ${{ secrets.BOT_GITHUB_USERNAME }}
-            do-push: ${{ github.event_name == 'push' }}
+          version: ${{ steps.calculate-next-internal-version.outputs.next-prerelease }}
+          chart-dir: ${{ env.CHART_DIR }}
+          helm-repository: ${{ env.HELM_REPO }}
+          helm-repository-branch: ${{ env.HELM_REPO_BRANCH }}
+          helm-repository-subfolder: ${{ env.HELM_REPO_SUBFOLDER }}
+          helm-repository-base-url: ${{ env.HELM_REPO_BASE_URL }}
+          helm-repository-token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          git-username: ${{ secrets.BOT_GITHUB_USERNAME }}
+          do-push: ${{ github.event_name == 'push' }}
 
   propagate:
     if: github.event_name == 'push'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,17 +81,21 @@ jobs:
 
       - id: helm-release-and-publish
         name: Release and publish helm chart
-        uses: Alfresco/alfresco-build-tools/.github/actions/helm-release-and-publish@v1.36.0
+        uses: Wandalen/wretry.action@1.3.0
         with:
-          version: ${{ steps.calculate-next-internal-version.outputs.next-prerelease }}
-          chart-dir: ${{ env.CHART_DIR }}
-          helm-repository: ${{ env.HELM_REPO }}
-          helm-repository-branch: ${{ env.HELM_REPO_BRANCH }}
-          helm-repository-subfolder: ${{ env.HELM_REPO_SUBFOLDER }}
-          helm-repository-base-url: ${{ env.HELM_REPO_BASE_URL }}
-          helm-repository-token: ${{ secrets.BOT_GITHUB_TOKEN }}
-          git-username: ${{ secrets.BOT_GITHUB_USERNAME }}
-          do-push: ${{ github.event_name == 'push' }}
+          action: Alfresco/alfresco-build-tools/.github/actions/helm-release-and-publish@v1.36.0
+          attempt_limit: 3
+          attempt_delay: 2000
+          with: |
+            version: ${{ steps.calculate-next-internal-version.outputs.next-prerelease }}
+            chart-dir: ${{ env.CHART_DIR }}
+            helm-repository: ${{ env.HELM_REPO }}
+            helm-repository-branch: ${{ env.HELM_REPO_BRANCH }}
+            helm-repository-subfolder: ${{ env.HELM_REPO_SUBFOLDER }}
+            helm-repository-base-url: ${{ env.HELM_REPO_BASE_URL }}
+            helm-repository-token: ${{ secrets.BOT_GITHUB_TOKEN }}
+            git-username: ${{ secrets.BOT_GITHUB_USERNAME }}
+            do-push: ${{ github.event_name == 'push' }}
 
   propagate:
     if: github.event_name == 'push'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
 
       - id: helm-release-and-publish
         name: Release and publish helm chart
-        uses: Wandalen/wretry.action@1.3.0
+        uses: Wandalen/wretry.action@v1.3.0
         with:
           action: Alfresco/alfresco-build-tools/.github/actions/helm-release-and-publish@v1.36.0
           attempt_limit: 3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,8 @@ jobs:
       - id: helm-release-and-publish
         name: Release and publish helm chart
         uses: Wandalen/wretry.action@v1.3.0
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         with:
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -32,7 +32,7 @@ jobs:
         name: Publish Helm chart
         uses: Wandalen/wretry.action@v1.3.0
         env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}        
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
         with:
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -30,7 +30,7 @@ jobs:
 
       - id: helm-publish-chart
         name: Publish Helm chart
-        uses: Wandalen/wretry.action@1.3.0
+        uses: Wandalen/wretry.action@v1.3.0
           action: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@v1.36.0
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -30,21 +30,15 @@ jobs:
 
       - id: helm-publish-chart
         name: Publish Helm chart
-        uses: Wandalen/wretry.action@v1.3.0
-        env:
-          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}
+        uses: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@dev-igdianov-AAE-16060
         with:
-          attempt_limit: 3
-          attempt_delay: 2000
-          action: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@v1.36.0
-          with: |
-            chart-package: ${{ steps.helm-package-chart.outputs.package-file-path }}
-            helm-charts-repo: ${{ env.HELM_REPO }}
-            helm-charts-repo-branch: ${{ env.HELM_REPO_BRANCH }}
-            helm-charts-repo-subfolder: ${{ env.HELM_REPO_SUBFOLDER }}
-            helm-charts-repo-base-url: ${{ env.HELM_REPO_BASE_URL }}
-            token: ${{ secrets.BOT_GITHUB_TOKEN }}
-            git-username: ${{ secrets.BOT_GITHUB_USERNAME }}
+          chart-package: ${{ steps.helm-package-chart.outputs.package-file-path }}
+          helm-charts-repo: ${{ env.HELM_REPO }}
+          helm-charts-repo-branch: ${{ env.HELM_REPO_BRANCH }}
+          helm-charts-repo-subfolder: ${{ env.HELM_REPO_SUBFOLDER }}
+          helm-charts-repo-base-url: ${{ env.HELM_REPO_BASE_URL }}
+          token: ${{ secrets.BOT_GITHUB_TOKEN }}
+          git-username: ${{ secrets.BOT_GITHUB_USERNAME }}
 
       - uses: Activiti/activiti-scripts/.github/actions/wait-for-chart@develop
         with:

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -31,6 +31,8 @@ jobs:
       - id: helm-publish-chart
         name: Publish Helm chart
         uses: Wandalen/wretry.action@v1.3.0
+        env:
+          GH_TOKEN: ${{ secrets.BOT_GITHUB_TOKEN }}        
         with:
           attempt_limit: 3
           attempt_delay: 2000

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -31,9 +31,10 @@ jobs:
       - id: helm-publish-chart
         name: Publish Helm chart
         uses: Wandalen/wretry.action@v1.3.0
-          action: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@v1.36.0
+        with:
           attempt_limit: 3
           attempt_delay: 2000
+          action: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@v1.36.0
           with: |
             chart-package: ${{ steps.helm-package-chart.outputs.package-file-path }}
             helm-charts-repo: ${{ env.HELM_REPO }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -30,15 +30,18 @@ jobs:
 
       - id: helm-publish-chart
         name: Publish Helm chart
-        uses: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@v1.36.0
-        with:
-          chart-package: ${{ steps.helm-package-chart.outputs.package-file-path }}
-          helm-charts-repo: ${{ env.HELM_REPO }}
-          helm-charts-repo-branch: ${{ env.HELM_REPO_BRANCH }}
-          helm-charts-repo-subfolder: ${{ env.HELM_REPO_SUBFOLDER }}
-          helm-charts-repo-base-url: ${{ env.HELM_REPO_BASE_URL }}
-          token: ${{ secrets.BOT_GITHUB_TOKEN }}
-          git-username: ${{ secrets.BOT_GITHUB_USERNAME }}
+        uses: Wandalen/wretry.action@1.3.0
+          action: Alfresco/alfresco-build-tools/.github/actions/helm-publish-chart@v1.36.0
+          attempt_limit: 3
+          attempt_delay: 2000
+          with: |
+            chart-package: ${{ steps.helm-package-chart.outputs.package-file-path }}
+            helm-charts-repo: ${{ env.HELM_REPO }}
+            helm-charts-repo-branch: ${{ env.HELM_REPO_BRANCH }}
+            helm-charts-repo-subfolder: ${{ env.HELM_REPO_SUBFOLDER }}
+            helm-charts-repo-base-url: ${{ env.HELM_REPO_BASE_URL }}
+            token: ${{ secrets.BOT_GITHUB_TOKEN }}
+            git-username: ${{ secrets.BOT_GITHUB_USERNAME }}
 
       - uses: Activiti/activiti-scripts/.github/actions/wait-for-chart@develop
         with:


### PR DESCRIPTION
To sync with remote before publishing helm package step in the case there are git client push errors due to concurrent remote modifications, i.e.

```
Run git push origin
To https://github.com/Alfresco/charts
 ! [rejected]        master -> master (fetch first)
error: failed to push some refs to 'https://github.com/Alfresco/charts'
hint: Updates were rejected because the remote contains work that you do
hint: not have locally. This is usually caused by another repository pushing
hint: to the same ref. You may want to first integrate the remote changes
hint: (e.g., 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Error: Process completed with exit code 1.

```

Depends on https://github.com/Alfresco/alfresco-build-tools/pull/324