### PR TITLE
AAE-34591 Migrate to Teams workflow webhook

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,6 +134,6 @@ jobs:
     if: always() && failure() && github.event_name == 'push'
     steps:
       - name: Teams Notification
-        uses: Alfresco/alfresco-build-tools/.github/actions/send-teams-notification@1713976b6d7dc48dfe74f441c9bf1ae9481cbb45 # v8.6.1
+        uses: Alfresco/alfresco-build-tools/.github/actions/send-teams-notification@95f68dc050fba62b3331d9b47bc659526cdfb343 # v8.21.1
         with:
-          webhook-url: ${{ secrets.TEAMS_NOTIFICATION_WEBHOOK }}
+          webhook-url: ${{ secrets.TEAMS_NOTIFICATION_WORKFLOW_WEBHOOK }}

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -54,6 +54,6 @@ jobs:
     if: always() && failure() && github.event_name == 'push'
     steps:
       - name: Teams Notification
-        uses: Alfresco/alfresco-build-tools/.github/actions/send-teams-notification@1713976b6d7dc48dfe74f441c9bf1ae9481cbb45 # v8.6.1
+        uses: Alfresco/alfresco-build-tools/.github/actions/send-teams-notification@95f68dc050fba62b3331d9b47bc659526cdfb343 # v8.21.1
         with:
-          webhook-url: ${{ secrets.TEAMS_NOTIFICATION_WEBHOOK }}
+          webhook-url: ${{ secrets.TEAMS_NOTIFICATION_WORKFLOW_WEBHOOK }}


### PR DESCRIPTION
Migrating to the new Teams workflow webhook as the legacy ones are going to reach EoL by end of year.